### PR TITLE
docs: update self-hosted Helm values to match mo-infrastructure chart

### DIFF
--- a/cluster-management/self-hosted.mdx
+++ b/cluster-management/self-hosted.mdx
@@ -28,7 +28,7 @@ The platform services require a few secrets containing critical credentials that
 **1. Container Registry**  
 After obtaining a subscription for the self-hosted version, you will have received credentials for the container registry where the platform images are stored. In your `mogenius-platform` namespace create a new secret `mo-registry-credentials` and store the credentials as type `kubernetes.io/dockerconfigjson`.
 
-**2. Redis**  
+**2. Valkey (Redis-compatible)**  
 Create a secret `mo-redis-secret` with the key `REDIS_SECRET`. Define a secure password as a value that you store in a safe place (e.g. a vault).
 
 **3. Encryption Key**  
@@ -122,8 +122,6 @@ mysql:
 storage:
   accessMode: ReadWriteOnce
   className: local-path
-  persistentVolume:
-    create: false
 ```
 
 <Warning>
@@ -158,295 +156,324 @@ Need help setting up the mogenius platform? Contact us via [support@mogenius.com
 
 ## Values
 
+### Global Settings
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| demo.enabled | bool | `true` |  |
-| demo.secretName | string | `"mo-platform-demo"` |  |
-| dockersecrets | object | `{}` |  |
-| global.imagePullSecrets | list | `[]` | list(of string) set the image pull secrets for all images |
-| global.serviceMonitor.fallbackScrapeProtocol | string | `"PrometheusText0.0.4"` | fallback scrape protocol for service monitors |
-| ingress.annotations | object | `{"traefik.ingress.kubernetes.io/forward-headers":"true","traefik.ingress.kubernetes.io/router.middlewares":"mogenius-cors-middleware@kubernetescrd","traefik.ingress.kubernetes.io/secure-headers":"true"}` | annotations to be placed on the ingress |
-| ingress.api_service_url | string | `nil` | api hostname e.g. api-app.example.com |
-| ingress.hostname | string | `nil` | platform hostname e.g. app.example.com |
-| ingress.ingressClassName | string | `"traefik"` |  |
-| ingress.k8s_cmd_stream_url | string | `nil` | kubernetes cmd stream hostname e.g. k8s-cmd-stream.example.com |
-| ingress.k8s_dispatcher_url | string | `nil` | kubernetes dispatcher hostname e.g. k8s-dispatcher.example.com |
-| ingress.k8s_logs_url | string | `nil` | kubernetes log hostname e.g. k8s-logs.example.com |
-| ingress.k8s_websocket_url | string | `nil` | kubernetes websocket hostname e.g. k8s-ws.example.com |
-| ingress.rootDomain | string | `nil` | Root domain that the platorm will be hosted on, e.g. example.com |
-| ingress.socket_service_url | string | `nil` | websocket hostname e.g. ws-app.example.com |
-| ingress.tls | list | `[]` | secret reference for tls |
-| ingress.traefik | object | `{"apiVersion":"traefik.containo.us/v1alpha1"}` | traefik specific settings |
-| ingress.traefik.apiVersion | string | `"traefik.containo.us/v1alpha1"` | the apiVersion that shall be used for traefik resources |
-| ingress.user_service_url | string | `nil` | user service hostname e.g. user-app.example.com |
-| mo_platform.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
-| mo_platform.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| mo_platform.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
-| mo_platform.enabled | bool | `true` |  |
-| mo_platform.image.registry | string | `"ghcr.io"` |  |
-| mo_platform.image.repository | string | `"mogenius/mo-frontend"` |  |
-| mo_platform.image.tag | string | `"v2.5.7"` |  |
-| mo_platform.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mo_platform.metrics | object | `{"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true},"enabled":false,"image":{"registry":"docker.io","repository":"nginx/nginx-prometheus-exporter","tag":"1.5.1"},"port":9113,"resources":{},"serviceMonitor":{"enabled":false}}` | prometheus exporter for nginx |
-| mo_platform.podSecurityContext.fsGroup | int | `101` |  |
-| mo_platform.podSecurityContext.runAsUser | int | `101` |  |
-| mo_platform.podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| mo_platform.port | int | `8080` |  |
-| mo_platform.replicas | int | `1` |  |
-| mo_platform.resources | object | `{}` |  |
-| mo_platform.tolerations | object | `{}` |  |
-| mo_platform_api.containerSecurityContext | object | `{}` |  |
-| mo_platform_api.enableAutoRefreshToken | bool | `false` |  |
-| mo_platform_api.enabled | bool | `true` |  |
-| mo_platform_api.image.registry | string | `"ghcr.io"` |  |
-| mo_platform_api.image.repository | string | `"mogenius/mo-platform-api-service"` |  |
-| mo_platform_api.image.tag | string | `"v3.0.23"` |  |
-| mo_platform_api.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mo_platform_api.initContainer.containerSecurityContext | object | `{}` |  |
-| mo_platform_api.initContainer.image.registry | string | `"docker.io"` |  |
-| mo_platform_api.initContainer.image.repository | string | `"alpine/curl"` |  |
-| mo_platform_api.initContainer.image.tag | string | `"8.14.1"` |  |
-| mo_platform_api.podSecurityContext | object | `{}` |  |
-| mo_platform_api.port | int | `1337` |  |
-| mo_platform_api.port_tcp | int | `7000` |  |
-| mo_platform_api.probes.enabled | bool | `true` |  |
-| mo_platform_api.probes.livenessProbe.enabled | bool | `true` |  |
-| mo_platform_api.probes.livenessProbe.path | string | `"/core/status"` |  |
-| mo_platform_api.probes.port | int | `1337` |  |
-| mo_platform_api.probes.readinessProbe.enabled | bool | `true` |  |
-| mo_platform_api.probes.readinessProbe.path | string | `"/core/status"` |  |
-| mo_platform_api.probes.startupProbe.enabled | bool | `true` |  |
-| mo_platform_api.probes.startupProbe.path | string | `"/core/status"` |  |
-| mo_platform_api.refreshTokenTask | bool | `false` | if set to true will refresh the tokens in the database |
-| mo_platform_api.replicas | int | `1` |  |
-| mo_platform_api.resources | object | `{}` |  |
-| mo_platform_api.sshSymEncKey.secretKey | string | `"MO_CORE_NEST__SSH_SYM_ENC_KEY"` |  |
-| mo_platform_api.sshSymEncKey.secretName | string | `"mo-platform-shared"` |  |
-| mo_platform_api.tolerations | object | `{}` |  |
-| mo_platform_api.ws_cmd_stream_port | int | `7003` |  |
-| mo_platform_api.ws_log_port | int | `7002` |  |
-| mo_platform_api.ws_port | int | `7001` |  |
-| mo_platform_api_valkey.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
-| mo_platform_api_valkey.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| mo_platform_api_valkey.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
-| mo_platform_api_valkey.containerSecurityContext.runAsGroup | int | `999` |  |
-| mo_platform_api_valkey.containerSecurityContext.runAsNonRoot | bool | `true` |  |
-| mo_platform_api_valkey.containerSecurityContext.runAsUser | int | `999` |  |
-| mo_platform_api_valkey.enabled | bool | `true` |  |
-| mo_platform_api_valkey.host | string | `"mo-platform-api-valkey"` |  |
-| mo_platform_api_valkey.image.registry | string | `"docker.io"` |  |
-| mo_platform_api_valkey.image.repository | string | `"valkey/valkey"` |  |
-| mo_platform_api_valkey.image.tag | float | `8.1` |  |
-| mo_platform_api_valkey.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mo_platform_api_valkey.password.secretKey | string | `"REDIS_SECRET"` |  |
-| mo_platform_api_valkey.password.secretName | string | `"mo-redis-secret"` |  |
-| mo_platform_api_valkey.podSecurityContext.fsGroup | int | `999` |  |
-| mo_platform_api_valkey.podSecurityContext.runAsGroup | int | `999` |  |
-| mo_platform_api_valkey.podSecurityContext.runAsUser | int | `999` |  |
-| mo_platform_api_valkey.podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| mo_platform_api_valkey.port | int | `6379` |  |
-| mo_platform_api_valkey.resources | object | `{}` |  |
-| mo_platform_message_dispatcher.containerSecurityContext | object | `{}` |  |
-| mo_platform_message_dispatcher.enabled | bool | `true` |  |
-| mo_platform_message_dispatcher.image.registry | string | `"ghcr.io"` |  |
-| mo_platform_message_dispatcher.image.repository | string | `"mogenius/mo-platform-message-dispatcher"` |  |
-| mo_platform_message_dispatcher.image.tag | string | `"v1.1.1"` |  |
-| mo_platform_message_dispatcher.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mo_platform_message_dispatcher.listen_host | string | `"0.0.0.0"` |  |
-| mo_platform_message_dispatcher.podSecurityContext | object | `{}` |  |
-| mo_platform_message_dispatcher.port | int | `7060` |  |
-| mo_platform_message_dispatcher.redis.host | string | `"localhost"` |  |
-| mo_platform_message_dispatcher.redis.image.registry | string | `"docker.io"` |  |
-| mo_platform_message_dispatcher.redis.image.repository | string | `"redis"` |  |
-| mo_platform_message_dispatcher.redis.image.tag | string | `"7.4.6"` |  |
-| mo_platform_message_dispatcher.redis.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mo_platform_message_dispatcher.redis.password.secretKey | string | `"REDIS_SECRET"` |  |
-| mo_platform_message_dispatcher.redis.password.secretName | string | `"mo-redis-secret"` |  |
-| mo_platform_message_dispatcher.redis.port | int | `6379` |  |
-| mo_platform_message_dispatcher.redis.tls | bool | `false` |  |
-| mo_platform_message_dispatcher.replicas | int | `1` |  |
-| mo_platform_message_dispatcher.resources | object | `{}` |  |
-| mo_platform_message_dispatcher.tolerations | object | `{}` |  |
-| mo_platform_notification.containerSecurityContext | object | `{}` |  |
-| mo_platform_notification.email.fromAddress | string | `"no-reply@mogenius.com"` |  |
-| mo_platform_notification.email.fromName | string | `"Mogenius Team"` |  |
-| mo_platform_notification.enabled | bool | `true` |  |
-| mo_platform_notification.image.registry | string | `"ghcr.io"` |  |
-| mo_platform_notification.image.repository | string | `"mogenius/mo-platform-notification"` |  |
-| mo_platform_notification.image.tag | string | `"v2.0.2"` |  |
-| mo_platform_notification.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mo_platform_notification.podSecurityContext | object | `{}` |  |
-| mo_platform_notification.port | int | `7000` |  |
-| mo_platform_notification.replicas | int | `1` |  |
-| mo_platform_notification.resources | object | `{}` |  |
-| mo_platform_notification.sshSymEncKey.secretKey | string | `"MO_CORE_NEST__SSH_SYM_ENC_KEY"` |  |
-| mo_platform_notification.sshSymEncKey.secretName | string | `"mo-platform-shared"` |  |
-| mo_platform_notification.tolerations | object | `{}` |  |
-| mo_platform_queue.containerSecurityContext | object | `{}` |  |
-| mo_platform_queue.enabled | bool | `true` |  |
-| mo_platform_queue.image.registry | string | `"ghcr.io"` |  |
-| mo_platform_queue.image.repository | string | `"mogenius/mo-platform-queue"` |  |
-| mo_platform_queue.image.tag | string | `"v2.0.4"` |  |
-| mo_platform_queue.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mo_platform_queue.podSecurityContext | object | `{}` |  |
-| mo_platform_queue.redis.host | string | `"localhost"` |  |
-| mo_platform_queue.redis.image.registry | string | `"docker.io"` |  |
-| mo_platform_queue.redis.image.repository | string | `"redis"` |  |
-| mo_platform_queue.redis.image.tag | string | `"7.4.6"` |  |
-| mo_platform_queue.redis.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mo_platform_queue.redis.password.secretKey | string | `"REDIS_SECRET"` |  |
-| mo_platform_queue.redis.password.secretName | string | `"mo-redis-secret"` |  |
-| mo_platform_queue.redis.port | int | `6379` |  |
-| mo_platform_queue.replicas | int | `1` |  |
-| mo_platform_queue.resources | object | `{}` |  |
-| mo_platform_queue.sshSymEncKey.secretKey | string | `"MO_CORE_NEST__SSH_SYM_ENC_KEY"` |  |
-| mo_platform_queue.sshSymEncKey.secretName | string | `"mo-platform-shared"` |  |
-| mo_platform_queue.tolerations | object | `{}` |  |
-| mo_platform_queue_valkey.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
-| mo_platform_queue_valkey.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| mo_platform_queue_valkey.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
-| mo_platform_queue_valkey.containerSecurityContext.runAsGroup | int | `999` |  |
-| mo_platform_queue_valkey.containerSecurityContext.runAsNonRoot | bool | `true` |  |
-| mo_platform_queue_valkey.containerSecurityContext.runAsUser | int | `999` |  |
-| mo_platform_queue_valkey.enabled | bool | `true` |  |
-| mo_platform_queue_valkey.host | string | `"mo-platform-queue-valkey"` |  |
-| mo_platform_queue_valkey.image.registry | string | `"docker.io"` |  |
-| mo_platform_queue_valkey.image.repository | string | `"valkey/valkey"` |  |
-| mo_platform_queue_valkey.image.tag | float | `8.1` |  |
-| mo_platform_queue_valkey.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mo_platform_queue_valkey.password.secretKey | string | `"REDIS_SECRET"` |  |
-| mo_platform_queue_valkey.password.secretName | string | `"mo-redis-secret"` |  |
-| mo_platform_queue_valkey.podSecurityContext.fsGroup | int | `999` |  |
-| mo_platform_queue_valkey.podSecurityContext.runAsGroup | int | `999` |  |
-| mo_platform_queue_valkey.podSecurityContext.runAsUser | int | `999` |  |
-| mo_platform_queue_valkey.podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| mo_platform_queue_valkey.port | int | `6379` |  |
-| mo_platform_queue_valkey.resources | object | `{}` |  |
-| mo_platform_user.containerSecurityContext | object | `{}` |  |
-| mo_platform_user.enabled | bool | `true` |  |
-| mo_platform_user.image.registry | string | `"ghcr.io"` |  |
-| mo_platform_user.image.repository | string | `"mogenius/mo-platform-user"` |  |
-| mo_platform_user.image.tag | string | `"v2.0.4"` |  |
-| mo_platform_user.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mo_platform_user.openid.accessTokenLifetime | int | `600` |  |
-| mo_platform_user.openid.adminAccessTokenLifetime | int | `28800` |  |
-| mo_platform_user.openid.enabled | bool | `true` |  |
-| mo_platform_user.openid.issuer | string | `"https://login-dev.mogenius.com"` |  |
-| mo_platform_user.openid.provider | object | `{"github":{"displayName":"GitHub","enabled":false,"secretKey":"github","secretName":"mo-openid-secret"},"gitlab":{"displayName":"GitLab","enabled":false,"secretKey":"gitlab","secretName":"mo-openid-secret"},"google":{"displayName":"Google","enabled":false,"secretKey":"google","secretName":"mo-openid-secret"},"linkedin":{"displayName":"LinkedIn","enabled":false,"secretKey":"linkedin","secretName":"mo-openid-secret"},"microsoft":{"displayName":"Microsoft","enabled":false,"secretKey":"microsoft","secretName":"mo-openid-secret"}}` | open id provider, e.g. openid.provider.gitlab.secret: `<your-secret>` |
-| mo_platform_user.openid.refreshTokenLifetime | int | `7776000` |  |
-| mo_platform_user.podSecurityContext | object | `{}` |  |
-| mo_platform_user.port | int | `1337` |  |
-| mo_platform_user.port_ws | int | `7000` |  |
-| mo_platform_user.probes.enabled | bool | `true` |  |
-| mo_platform_user.probes.livenessProbe.enabled | bool | `true` |  |
-| mo_platform_user.probes.livenessProbe.path | string | `"/core/status"` |  |
-| mo_platform_user.probes.port | int | `1337` |  |
-| mo_platform_user.probes.readinessProbe.enabled | bool | `true` |  |
-| mo_platform_user.probes.readinessProbe.path | string | `"/core/status"` |  |
-| mo_platform_user.probes.startupProbe.enabled | bool | `true` |  |
-| mo_platform_user.probes.startupProbe.path | string | `"/core/status"` |  |
-| mo_platform_user.redis.host | string | `"localhost"` |  |
-| mo_platform_user.redis.image.registry | string | `"docker.io"` |  |
-| mo_platform_user.redis.image.repository | string | `"redis"` |  |
-| mo_platform_user.redis.image.tag | string | `"7.4.6"` |  |
-| mo_platform_user.redis.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mo_platform_user.redis.password.secretKey | string | `"REDIS_SECRET"` |  |
-| mo_platform_user.redis.password.secretName | string | `"mo-redis-secret"` |  |
-| mo_platform_user.redis.port | int | `6379` |  |
-| mo_platform_user.replicas | int | `1` |  |
-| mo_platform_user.resources | object | `{}` |  |
-| mo_platform_user.sshSymEncKey.secretKey | string | `"MO_CORE_NEST__SSH_SYM_ENC_KEY"` |  |
-| mo_platform_user.sshSymEncKey.secretName | string | `"mo-platform-shared"` |  |
-| mo_platform_user.tolerations | object | `{}` |  |
-| mo_platform_websocket.containerSecurityContext | object | `{}` |  |
-| mo_platform_websocket.enabled | bool | `true` |  |
-| mo_platform_websocket.image.registry | string | `"ghcr.io"` |  |
-| mo_platform_websocket.image.repository | string | `"mogenius/mo-platform-websocket"` |  |
-| mo_platform_websocket.image.tag | string | `"v2.0.2"` |  |
-| mo_platform_websocket.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mo_platform_websocket.podSecurityContext | object | `{}` |  |
-| mo_platform_websocket.port | int | `1337` |  |
-| mo_platform_websocket.port_ws | int | `7000` |  |
-| mo_platform_websocket.replicas | int | `1` |  |
-| mo_platform_websocket.resources | object | `{}` |  |
-| mo_platform_websocket.sshSymEncKey.secretKey | string | `"MO_CORE_NEST__SSH_SYM_ENC_KEY"` |  |
-| mo_platform_websocket.sshSymEncKey.secretName | string | `"mo-platform-shared"` |  |
-| mo_platform_websocket.tolerations | object | `{}` |  |
-| mogenius.imagePullSecrets | list | `[]` | list(of string) set the image pull secret for mogenius images |
-| mysql.allow_empty_root_password | int | `0` |  |
-| mysql.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
-| mysql.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| mysql.containerSecurityContext.readOnlyRootFilesystem | bool | `false` |  |
-| mysql.containerSecurityContext.runAsGroup | int | `999` |  |
-| mysql.containerSecurityContext.runAsNonRoot | bool | `true` |  |
-| mysql.containerSecurityContext.runAsUser | int | `999` |  |
-| mysql.database | string | `"platform"` |  |
-| mysql.enabled | bool | `false` |  |
-| mysql.host | string | `"mysql"` |  |
-| mysql.image.registry | string | `"docker.io"` |  |
-| mysql.image.repository | string | `"mysql"` |  |
-| mysql.image.tag | string | `"8.4.7"` |  |
-| mysql.imagePullPolicy | string | `"IfNotPresent"` |  |
-| mysql.mountpoint | string | `"/var/lib/mysql"` |  |
-| mysql.password.secretKey | string | `"MYSQL_PASSWORD"` |  |
-| mysql.password.secretName | string | `"mo-mysql-secret"` |  |
-| mysql.podSecurityContext.fsGroup | int | `999` |  |
-| mysql.port | int | `3306` |  |
-| mysql.replicas | int | `1` |  |
-| mysql.resources | object | `{}` |  |
-| mysql.root_password.secretKey | string | `"MYSQL_ROOT_PASSWORD"` |  |
-| mysql.root_password.secretName | string | `"mo-mysql-secret"` |  |
-| mysql.ssl | bool | `false` |  |
-| mysql.sslRejectUnauthorized | bool | `true` |  |
-| mysql.subpath | string | `"{{ tpl .Release.Namespace }}-mysql-storage"` |  |
-| mysql.tolerations | object | `{}` |  |
-| mysql.user | string | `"platform_user"` |  |
-| platform_websocket_redis.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
-| platform_websocket_redis.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| platform_websocket_redis.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
-| platform_websocket_redis.containerSecurityContext.runAsGroup | int | `999` |  |
-| platform_websocket_redis.containerSecurityContext.runAsNonRoot | bool | `true` |  |
-| platform_websocket_redis.containerSecurityContext.runAsUser | int | `999` |  |
-| platform_websocket_redis.enabled | bool | `true` |  |
-| platform_websocket_redis.host | string | `"mo-platform-websocket-redis"` |  |
-| platform_websocket_redis.image.registry | string | `"docker.io"` |  |
-| platform_websocket_redis.image.repository | string | `"redis"` |  |
-| platform_websocket_redis.image.tag | string | `"7.4.6"` |  |
-| platform_websocket_redis.imagePullPolicy | string | `"IfNotPresent"` |  |
-| platform_websocket_redis.password.secretKey | string | `"REDIS_SECRET"` |  |
-| platform_websocket_redis.password.secretName | string | `"mo-redis-secret"` |  |
-| platform_websocket_redis.podSecurityContext.fsGroup | int | `999` |  |
-| platform_websocket_redis.port | int | `6379` |  |
-| platform_websocket_redis.replicas | int | `1` |  |
-| platform_websocket_redis.resources | object | `{}` |  |
-| platform_websocket_redis.tolerations | object | `{}` |  |
-| progressDeadlineSeconds | int | `600` |  |
-| redis_master.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
-| redis_master.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| redis_master.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
-| redis_master.containerSecurityContext.runAsGroup | int | `999` |  |
-| redis_master.containerSecurityContext.runAsNonRoot | bool | `true` |  |
-| redis_master.containerSecurityContext.runAsUser | int | `999` |  |
-| redis_master.enabled | bool | `true` |  |
-| redis_master.host | string | `"redis-master"` |  |
-| redis_master.image.registry | string | `"docker.io"` |  |
-| redis_master.image.repository | string | `"redis"` |  |
-| redis_master.image.tag | string | `"7.4.6"` |  |
-| redis_master.imagePullPolicy | string | `"IfNotPresent"` |  |
-| redis_master.password.secretKey | string | `"REDIS_SECRET"` |  |
-| redis_master.password.secretName | string | `"mo-redis-secret"` |  |
-| redis_master.podSecurityContext.fsGroup | int | `999` |  |
-| redis_master.port | int | `6379` |  |
-| redis_master.queue_db | int | `7` |  |
-| redis_master.replicas | int | `1` |  |
-| redis_master.resources | object | `{}` |  |
-| redis_master.tls | bool | `false` |  |
-| redis_master.tolerations | object | `{}` |  |
-| revisionHistoryLimit | int | `1` | global revisionHistorylimit for all resources |
+| stage | string | `"production"` | Current environment, one of [dev, production] |
+| revisionHistoryLimit | int | `1` | Global revisionHistoryLimit for all resources |
+| progressDeadlineSeconds | int | `600` | Deployment progress deadline |
 | secrets | object | `{}` | secrets.`<secretName>`.`<secretKey>`.`<secretValue>` |
-| stage | string | `"production"` | current environment, one of [dev, production] |
-| storage.accessMode | string | `"ReadWriteMany"` |  |
-| storage.className | string | `"default"` |  |
-| storage.persistentVolume.basePath | string | `"/data"` | basePath for pv's ${basePath}/mysql and ${basePath}/redis must be present on host machine |
-| storage.persistentVolume.create | bool | `true` |  |
-| storage.persistentVolume.nodeAffinity | object | `{}` |  |
+| dockersecrets | object | `{}` | Docker registry secrets |
+| mogenius.imagePullSecrets | list | `[]` | List of image pull secrets for mogenius images |
+| global.imagePullSecrets | list | `[]` | List of image pull secrets for all images |
+| global.serviceMonitor.fallbackScrapeProtocol | string | `"PrometheusText0.0.4"` | Fallback scrape protocol for service monitors |
+| global.podLabels | object | `{}` | Global pod labels applied to all pods |
+
+### Ingress
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| ingress.rootDomain | string | `nil` | Root domain that the platform will be hosted on, e.g. example.com |
+| ingress.ingressClassName | string | `"traefik"` | Ingress class name |
+| ingress.annotations | object | See below | Annotations to be placed on the ingress |
+| ingress.tls | list | `[]` | Secret reference for TLS |
+| ingress.hostname | string | `nil` | Platform hostname e.g. app.example.com |
+| ingress.api_service_url | string | `nil` | API hostname e.g. api-app.example.com |
+| ingress.user_service_url | string | `nil` | User service hostname e.g. user-app.example.com |
+| ingress.socket_service_url | string | `nil` | WebSocket hostname e.g. ws-app.example.com |
+| ingress.k8s_websocket_url | string | `nil` | Kubernetes WebSocket hostname e.g. k8s-ws.example.com |
+| ingress.k8s_logs_url | string | `nil` | Kubernetes log hostname e.g. k8s-logs.example.com |
+| ingress.k8s_cmd_stream_url | string | `nil` | Kubernetes cmd stream hostname e.g. k8s-cmd-stream.example.com |
+| ingress.k8s_dispatcher_url | string | `nil` | Kubernetes dispatcher hostname e.g. k8s-dispatcher.example.com |
+| ingress.traefik.apiVersion | string | `"traefik.containo.us/v1alpha1"` | The apiVersion that shall be used for traefik resources |
+
+Default ingress annotations:
+```yaml
+traefik.ingress.kubernetes.io/router.middlewares: mogenius-cors-middleware@kubernetescrd
+traefik.ingress.kubernetes.io/forward-headers: "true"
+traefik.ingress.kubernetes.io/secure-headers: "true"
+```
+
+### Feature Toggles
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| features.sso.enabled | bool | `true` | Enable SSO feature with ingress for SSO wildcard domain |
+| features.sso.ingress.tls | list | `[]` | TLS configuration for SSO ingress |
+| features.sso.ingress.annotations | object | `{}` | Annotations for SSO ingress |
+| features.portForwarding.enabled | bool | `true` | Enable port forwarding feature |
+| features.portForwarding.hostname | string | `"tunnel.mogenius.com"` | Hostname for port forwarding |
+| features.portForwarding.ingress.tls | list | `[]` | TLS configuration for port forwarding ingress |
+| features.portForwarding.ingress.annotations | object | `{}` | Annotations for port forwarding ingress |
+
+### Platform Services
+
+#### mo_platform (Frontend)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_platform.enabled | bool | `true` | Enable frontend service |
+| mo_platform.replicas | int | `1` | Number of replicas |
+| mo_platform.image.registry | string | `"ghcr.io"` | Image registry |
+| mo_platform.image.repository | string | `"mogenius/mo-frontend"` | Image repository |
+| mo_platform.image.tag | string | `"v2.8.3"` | Image tag |
+| mo_platform.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| mo_platform.port | int | `8080` | Service port |
+| mo_platform.resources | object | `{}` | Resource requests/limits |
+| mo_platform.tolerations | object | `{}` | Pod tolerations |
+| mo_platform.metrics.enabled | bool | `false` | Enable Prometheus metrics exporter for nginx |
+| mo_platform.metrics.port | int | `9113` | Metrics port |
+| mo_platform.metrics.serviceMonitor.enabled | bool | `false` | Enable ServiceMonitor |
+
+#### mo_platform_api (API Service)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_platform_api.enabled | bool | `true` | Enable API service |
+| mo_platform_api.replicas | int | `1` | Number of replicas |
+| mo_platform_api.image.registry | string | `"ghcr.io"` | Image registry |
+| mo_platform_api.image.repository | string | `"mogenius/mo-platform-api-service"` | Image repository |
+| mo_platform_api.image.tag | string | `"v4.4.6"` | Image tag |
+| mo_platform_api.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| mo_platform_api.port | int | `1337` | HTTP port |
+| mo_platform_api.port_tcp | int | `7000` | TCP port |
+| mo_platform_api.ws_port | int | `7001` | WebSocket port |
+| mo_platform_api.ws_log_port | int | `7002` | WebSocket log port |
+| mo_platform_api.ws_cmd_stream_port | int | `7003` | WebSocket cmd stream port |
+| mo_platform_api.refreshTokenTask | bool | `false` | If set to true will refresh the tokens in the database |
+| mo_platform_api.enableAutoRefreshToken | bool | `false` | Enable automatic token refresh |
+| mo_platform_api.resources | object | `{}` | Resource requests/limits |
+| mo_platform_api.tolerations | object | `{}` | Pod tolerations |
+| mo_platform_api.probes.enabled | bool | `true` | Enable health probes |
+| mo_platform_api.probes.port | int | `1337` | Probe port |
+| mo_platform_api.probes.livenessProbe.path | string | `"/core/status"` | Liveness probe path |
+| mo_platform_api.probes.readinessProbe.path | string | `"/core/status"` | Readiness probe path |
+| mo_platform_api.probes.startupProbe.path | string | `"/core/status"` | Startup probe path |
+| mo_platform_api.sshSymEncKey.secretName | string | `"mo-platform-shared"` | Secret name for SSH symmetric encryption key |
+| mo_platform_api.sshSymEncKey.secretKey | string | `"MO_CORE_NEST__SSH_SYM_ENC_KEY"` | Secret key for SSH symmetric encryption key |
+| mo_platform_api.initContainer.image.registry | string | `"docker.io"` | Init container image registry |
+| mo_platform_api.initContainer.image.repository | string | `"alpine/curl"` | Init container image repository |
+| mo_platform_api.initContainer.image.tag | string | `"8.20.0"` | Init container image tag |
+
+#### mo_platform_user (User Service)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_platform_user.enabled | bool | `true` | Enable user service |
+| mo_platform_user.replicas | int | `1` | Number of replicas |
+| mo_platform_user.image.registry | string | `"ghcr.io"` | Image registry |
+| mo_platform_user.image.repository | string | `"mogenius/mo-platform-user"` | Image repository |
+| mo_platform_user.image.tag | string | `"v2.0.17"` | Image tag |
+| mo_platform_user.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| mo_platform_user.port | int | `1337` | HTTP port |
+| mo_platform_user.port_ws | int | `7000` | WebSocket port |
+| mo_platform_user.resources | object | `{}` | Resource requests/limits |
+| mo_platform_user.tolerations | object | `{}` | Pod tolerations |
+| mo_platform_user.probes.enabled | bool | `true` | Enable health probes |
+| mo_platform_user.sshSymEncKey.secretName | string | `"mo-platform-shared"` | Secret name for SSH symmetric encryption key |
+| mo_platform_user.sshSymEncKey.secretKey | string | `"MO_CORE_NEST__SSH_SYM_ENC_KEY"` | Secret key for SSH symmetric encryption key |
+
+**OpenID Configuration:**
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_platform_user.openid.enabled | bool | `true` | Enable OpenID |
+| mo_platform_user.openid.issuer | string | `"https://login-dev.mogenius.com"` | OpenID issuer URL |
+| mo_platform_user.openid.accessTokenLifetime | string | `"600"` | Access token lifetime in seconds |
+| mo_platform_user.openid.refreshTokenLifetime | string | `"7776000"` | Refresh token lifetime in seconds |
+| mo_platform_user.openid.adminAccessTokenLifetime | string | `"28800"` | Admin access token lifetime in seconds |
+| mo_platform_user.openid.provider.github.enabled | bool | `false` | Enable GitHub OAuth |
+| mo_platform_user.openid.provider.gitlab.enabled | bool | `false` | Enable GitLab OAuth |
+| mo_platform_user.openid.provider.google.enabled | bool | `false` | Enable Google OAuth |
+| mo_platform_user.openid.provider.linkedin.enabled | bool | `false` | Enable LinkedIn OAuth |
+| mo_platform_user.openid.provider.microsoft.enabled | bool | `false` | Enable Microsoft OAuth |
+
+#### mo_platform_websocket (WebSocket Service)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_platform_websocket.enabled | bool | `true` | Enable WebSocket service |
+| mo_platform_websocket.replicas | int | `1` | Number of replicas |
+| mo_platform_websocket.image.registry | string | `"ghcr.io"` | Image registry |
+| mo_platform_websocket.image.repository | string | `"mogenius/mo-platform-websocket"` | Image repository |
+| mo_platform_websocket.image.tag | string | `"v2.0.7"` | Image tag |
+| mo_platform_websocket.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| mo_platform_websocket.port | int | `1337` | HTTP port |
+| mo_platform_websocket.port_ws | int | `7000` | WebSocket port |
+| mo_platform_websocket.resources | object | `{}` | Resource requests/limits |
+| mo_platform_websocket.tolerations | object | `{}` | Pod tolerations |
+| mo_platform_websocket.sshSymEncKey.secretName | string | `"mo-platform-shared"` | Secret name for SSH symmetric encryption key |
+| mo_platform_websocket.sshSymEncKey.secretKey | string | `"MO_CORE_NEST__SSH_SYM_ENC_KEY"` | Secret key for SSH symmetric encryption key |
+
+#### mo_platform_notification (Notification Service)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_platform_notification.enabled | bool | `true` | Enable notification service |
+| mo_platform_notification.replicas | int | `1` | Number of replicas |
+| mo_platform_notification.image.registry | string | `"ghcr.io"` | Image registry |
+| mo_platform_notification.image.repository | string | `"mogenius/mo-platform-notification"` | Image repository |
+| mo_platform_notification.image.tag | string | `"v2.0.7"` | Image tag |
+| mo_platform_notification.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| mo_platform_notification.port | int | `7000` | Service port |
+| mo_platform_notification.email.fromName | string | `"Mogenius Team"` | Email sender name |
+| mo_platform_notification.email.fromAddress | string | `"no-reply@mogenius.com"` | Email sender address |
+| mo_platform_notification.resources | object | `{}` | Resource requests/limits |
+| mo_platform_notification.tolerations | object | `{}` | Pod tolerations |
+| mo_platform_notification.sshSymEncKey.secretName | string | `"mo-platform-shared"` | Secret name for SSH symmetric encryption key |
+| mo_platform_notification.sshSymEncKey.secretKey | string | `"MO_CORE_NEST__SSH_SYM_ENC_KEY"` | Secret key for SSH symmetric encryption key |
+
+#### mo_platform_queue (Queue Service)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_platform_queue.enabled | bool | `true` | Enable queue service |
+| mo_platform_queue.replicas | int | `1` | Number of replicas |
+| mo_platform_queue.image.registry | string | `"ghcr.io"` | Image registry |
+| mo_platform_queue.image.repository | string | `"mogenius/mo-platform-queue"` | Image repository |
+| mo_platform_queue.image.tag | string | `"v3.0.4"` | Image tag |
+| mo_platform_queue.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| mo_platform_queue.resources | object | `{}` | Resource requests/limits |
+| mo_platform_queue.tolerations | object | `{}` | Pod tolerations |
+| mo_platform_queue.sshSymEncKey.secretName | string | `"mo-platform-shared"` | Secret name for SSH symmetric encryption key |
+| mo_platform_queue.sshSymEncKey.secretKey | string | `"MO_CORE_NEST__SSH_SYM_ENC_KEY"` | Secret key for SSH symmetric encryption key |
+
+#### mo_platform_message_dispatcher (Message Dispatcher)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_platform_message_dispatcher.enabled | bool | `true` | Enable message dispatcher |
+| mo_platform_message_dispatcher.replicas | int | `1` | Number of replicas |
+| mo_platform_message_dispatcher.image.registry | string | `"ghcr.io"` | Image registry |
+| mo_platform_message_dispatcher.image.repository | string | `"mogenius/mo-platform-message-dispatcher"` | Image repository |
+| mo_platform_message_dispatcher.image.tag | string | `"v1.1.4"` | Image tag |
+| mo_platform_message_dispatcher.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| mo_platform_message_dispatcher.listen_host | string | `"0.0.0.0"` | Listen host |
+| mo_platform_message_dispatcher.port | int | `7060` | Service port |
+| mo_platform_message_dispatcher.resources | object | `{}` | Resource requests/limits |
+| mo_platform_message_dispatcher.tolerations | object | `{}` | Pod tolerations |
+
+### Valkey (Redis-compatible Cache)
+
+The platform uses [Valkey](https://valkey.io/), an open-source Redis-compatible in-memory data store, for caching and message queuing. The chart deploys multiple Valkey instances for different purposes.
+
+#### mo_platform_api_valkey
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_platform_api_valkey.enabled | bool | `true` | Enable Valkey for API service |
+| mo_platform_api_valkey.image.registry | string | `"docker.io"` | Image registry |
+| mo_platform_api_valkey.image.repository | string | `"valkey/valkey"` | Image repository |
+| mo_platform_api_valkey.image.tag | string | `"9.1.0"` | Image tag |
+| mo_platform_api_valkey.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| mo_platform_api_valkey.port | int | `6379` | Service port |
+| mo_platform_api_valkey.host | string | `"mo-platform-api-valkey"` | Service hostname |
+| mo_platform_api_valkey.password.secretName | string | `"mo-redis-secret"` | Secret name for password |
+| mo_platform_api_valkey.password.secretKey | string | `"REDIS_SECRET"` | Secret key for password |
+| mo_platform_api_valkey.resources | object | `{}` | Resource requests/limits |
+| mo_platform_api_valkey.metrics.enabled | bool | `false` | Enable Prometheus metrics exporter |
+| mo_platform_api_valkey.metrics.port | int | `9121` | Metrics port |
+| mo_platform_api_valkey.metrics.serviceMonitor.enabled | bool | `false` | Enable ServiceMonitor |
+
+#### mo_valkey_shared
+
+Shared Valkey instance used for queue processing and cross-service communication.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_valkey_shared.enabled | bool | `true` | Enable shared Valkey |
+| mo_valkey_shared.tls | bool | `false` | Enable TLS |
+| mo_valkey_shared.queue_db | int | `7` | Database number for queue |
+| mo_valkey_shared.image.registry | string | `"docker.io"` | Image registry |
+| mo_valkey_shared.image.repository | string | `"valkey/valkey"` | Image repository |
+| mo_valkey_shared.image.tag | string | `"9.1.0"` | Image tag |
+| mo_valkey_shared.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| mo_valkey_shared.port | int | `6379` | Service port |
+| mo_valkey_shared.host | string | `"mo-valkey-shared"` | Service hostname |
+| mo_valkey_shared.password.secretName | string | `"mo-redis-secret"` | Secret name for password |
+| mo_valkey_shared.password.secretKey | string | `"REDIS_SECRET"` | Secret key for password |
+| mo_valkey_shared.resources | object | `{}` | Resource requests/limits |
+| mo_valkey_shared.strategy | string | `"RollingUpdate"` | Update strategy |
+| mo_valkey_shared.metrics.enabled | bool | `false` | Enable Prometheus metrics exporter |
+| mo_valkey_shared.metrics.serviceMonitor.enabled | bool | `false` | Enable ServiceMonitor |
+
+#### mo_websocket_valkey
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_websocket_valkey.enabled | bool | `true` | Enable Valkey for WebSocket service |
+| mo_websocket_valkey.image.registry | string | `"docker.io"` | Image registry |
+| mo_websocket_valkey.image.repository | string | `"valkey/valkey"` | Image repository |
+| mo_websocket_valkey.image.tag | string | `"9.1.0"` | Image tag |
+| mo_websocket_valkey.port | int | `6379` | Service port |
+| mo_websocket_valkey.host | string | `"mo-websocket-valkey"` | Service hostname |
+| mo_websocket_valkey.password.secretName | string | `"mo-redis-secret"` | Secret name for password |
+| mo_websocket_valkey.password.secretKey | string | `"REDIS_SECRET"` | Secret key for password |
+| mo_websocket_valkey.resources | object | `{}` | Resource requests/limits |
+| mo_websocket_valkey.metrics.enabled | bool | `false` | Enable Prometheus metrics exporter |
+
+#### mo_user_valkey
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_user_valkey.enabled | bool | `true` | Enable Valkey for user service |
+| mo_user_valkey.image.registry | string | `"docker.io"` | Image registry |
+| mo_user_valkey.image.repository | string | `"valkey/valkey"` | Image repository |
+| mo_user_valkey.image.tag | string | `"9.1.0"` | Image tag |
+| mo_user_valkey.port | int | `6379` | Service port |
+| mo_user_valkey.host | string | `"mo-user-valkey"` | Service hostname |
+| mo_user_valkey.password.secretName | string | `"mo-redis-secret"` | Secret name for password |
+| mo_user_valkey.password.secretKey | string | `"REDIS_SECRET"` | Secret key for password |
+| mo_user_valkey.resources | object | `{}` | Resource requests/limits |
+| mo_user_valkey.metrics.enabled | bool | `false` | Enable Prometheus metrics exporter |
+
+#### mo_message_dispatcher_valkey
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mo_message_dispatcher_valkey.enabled | bool | `true` | Enable Valkey for message dispatcher |
+| mo_message_dispatcher_valkey.image.registry | string | `"docker.io"` | Image registry |
+| mo_message_dispatcher_valkey.image.repository | string | `"valkey/valkey"` | Image repository |
+| mo_message_dispatcher_valkey.image.tag | string | `"9.1.0"` | Image tag |
+| mo_message_dispatcher_valkey.port | int | `6379` | Service port |
+| mo_message_dispatcher_valkey.host | string | `"mo-message-dispatcher-valkey"` | Service hostname |
+| mo_message_dispatcher_valkey.tls | bool | `false` | Enable TLS |
+| mo_message_dispatcher_valkey.password.secretName | string | `"mo-redis-secret"` | Secret name for password |
+| mo_message_dispatcher_valkey.password.secretKey | string | `"REDIS_SECRET"` | Secret key for password |
+| mo_message_dispatcher_valkey.resources | object | `{}` | Resource requests/limits |
+| mo_message_dispatcher_valkey.metrics.enabled | bool | `false` | Enable Prometheus metrics exporter |
+
+### MySQL
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| mysql.enabled | bool | `false` | Enable MySQL deployment (use external MySQL for production) |
+| mysql.replicas | int | `1` | Number of replicas |
+| mysql.image.registry | string | `"docker.io"` | Image registry |
+| mysql.image.repository | string | `"mysql"` | Image repository |
+| mysql.image.tag | string | `"8.4.10"` | Image tag |
+| mysql.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| mysql.port | int | `3306` | Service port |
+| mysql.host | string | `"mysql"` | Service hostname |
+| mysql.database | string | `"platform"` | Database name |
+| mysql.user | string | `"platform_user"` | Database user |
+| mysql.password.secretName | string | `"mo-mysql-secret"` | Secret name for password |
+| mysql.password.secretKey | string | `"MYSQL_PASSWORD"` | Secret key for password |
+| mysql.root_password.secretName | string | `"mo-mysql-secret"` | Secret name for root password |
+| mysql.root_password.secretKey | string | `"MYSQL_ROOT_PASSWORD"` | Secret key for root password |
+| mysql.ssl | bool | `false` | Enable SSL |
+| mysql.sslRejectUnauthorized | bool | `true` | Reject unauthorized SSL connections |
+| mysql.allow_empty_root_password | int | `0` | Allow empty root password (0 = no) |
+| mysql.subpath | string | `"{{ tpl .Release.Namespace }}-mysql-storage"` | Storage subpath |
+| mysql.mountpoint | string | `"/var/lib/mysql"` | Data mount point |
+| mysql.storage.capacity | string | `"50Gi"` | Storage capacity |
+| mysql.resources | object | `{}` | Resource requests/limits |
+| mysql.tolerations | object | `{}` | Pod tolerations |
+
+### Storage
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| storage.className | string | `"default"` | Storage class name |
+| storage.accessMode | string | `"ReadWriteMany"` | Access mode |


### PR DESCRIPTION
## Summary
- Migrates Redis documentation to Valkey (5 dedicated instances replacing sidecar pattern)
- Adds new feature toggles section for SSO and port forwarding configuration
- Updates all image versions to current releases (API v4.4.6, Frontend v2.8.3, etc.)
- Removes obsolete `demo.*`, `redis_master`, and sidecar redis configurations
- Restructures Values table into logical sections (Global, Ingress, Features, Services, Valkey, MySQL, Storage)

## Test plan
- [ ] Review rendered documentation at staging URL
- [ ] Verify all value keys match current mo-infrastructure chart
- [ ] Confirm example values.yaml still works for quickstart

🤖 Generated with [Claude Code](https://claude.com/claude-code)