### PR TITLE
docs: document deploying Blueprints via the API

### DIFF
--- a/deploying-applications/blueprints.mdx
+++ b/deploying-applications/blueprints.mdx
@@ -65,6 +65,8 @@ To deploy a Blueprint, navigate to the **Helm Charts** tab in your cluster and c
 
 After deployment, the Blueprint is a regular Helm release. You can view its status, resources, and values on the [Helm Charts](/deploying-applications/helm-charts) page and manage it like any other release.
 
+You can also deploy Blueprints programmatically — see [Deploy a Blueprint](/workspaces/mogenius-API#deploy-a-blueprint) in the API reference.
+
 ## GitOps integration
 
 When GitOps is enabled on your cluster, Blueprints can be deployed through the GitOps workflow. Activating the GitOps toggle during installation creates an Argo CD Application in your connected Git repository instead of installing the chart directly.

--- a/workspaces/mogenius-API.mdx
+++ b/workspaces/mogenius-API.mdx
@@ -71,6 +71,89 @@ curl --location --request PATCH 'https://platform-api.mogenius.com/helm/admin/YO
 
 </CodeGroup>
 
+## Deploy a Blueprint
+
+[Blueprints](/deploying-applications/blueprints) are pre-configured Helm charts. Deploying one via the API is a two-step flow:
+
+1. Read the blueprint to get its chart coordinates and default values.
+2. Install that chart with the Helm install endpoint.
+
+The target cluster is selected with the `cluster-id` header. Use a cluster-level API key (or a workspace-level key with editor permissions); installing requires editor/admin rights on the cluster.
+
+### 1. List blueprints
+
+```
+// HEADER
+Authorization: Bearer YOUR_CLUSTER_API_KEY
+cluster-id: YOUR_CLUSTER_ID
+
+GET https://platform-api.mogenius.com/helm/blueprints
+```
+
+Returns the catalog with each blueprint's `id`, `displayName`, `description`, `category`, and `tags`.
+
+### 2. Get a blueprint's details
+
+```
+// HEADER
+Authorization: Bearer YOUR_CLUSTER_API_KEY
+cluster-id: YOUR_CLUSTER_ID
+
+GET https://platform-api.mogenius.com/helm/blueprints/BLUEPRINT_ID
+```
+
+The response includes the blueprint's Helm `repository` and `chart` (name and version) plus its default install target (`namespace`, `release`) and default `values`. Use these to build the install request.
+
+### 3. Install the chart
+
+Install the blueprint's chart as a standard Helm release. For repository-based charts, the Helm repository must be added to the cluster first (the `chart` value has the form `REPO_NAME/CHART_NAME`).
+
+```
+// HEADER
+Authorization: Bearer YOUR_CLUSTER_API_KEY
+cluster-id: YOUR_CLUSTER_ID
+Content-Type: application/json
+
+POST https://platform-api.mogenius.com/helm/chart/install
+```
+
+```curl expandable
+// BODY
+{
+    "namespace": "YOUR_NAMESPACE",
+    "chart": "REPO_NAME/CHART_NAME",  // from the blueprint's chart
+    "release": "RELEASE_NAME",
+    "version": "CHART_VERSION",
+    "values": "key1: value1",          // YAML string with your value overrides
+    "dryRun": false
+}
+```
+
+For charts hosted in an OCI registry, use the OCI install endpoint instead:
+
+```
+// HEADER
+Authorization: Bearer YOUR_CLUSTER_API_KEY
+cluster-id: YOUR_CLUSTER_ID
+Content-Type: application/json
+
+POST https://platform-api.mogenius.com/helm/chart/oci/install
+```
+
+```curl expandable
+// BODY
+{
+    "ociChartUrl": "oci://REGISTRY/CHART",
+    "namespace": "YOUR_NAMESPACE",
+    "release": "RELEASE_NAME",
+    "version": "CHART_VERSION",   // optional
+    "values": "key1: value1",      // optional YAML string
+    "dryRun": false
+}
+```
+
+Once installed, the blueprint becomes a standard Helm release that you can manage through the [Helm upgrade](#helm-upgrade) endpoint or the [Helm Charts](/deploying-applications/helm-charts) interface.
+
 ## Manage Ports & Hostnames
 
 You can `get`, `add`, and `delete` ports and hostnames from deployments, just like from the UI. mogenius will automatically create or update the corresponding service and ingress resources.


### PR DESCRIPTION
## Summary

Documents how to deploy a Blueprint through the mogenius REST API.

- **Extended** `workspaces/mogenius-API.mdx` — new **Deploy a Blueprint** section (after Helm Upgrade):
  - Two-step flow: read the blueprint, then install its chart.
  - `GET /helm/blueprints` (catalog), `GET /helm/blueprints/{id}` (chart + defaults), `POST /helm/chart/install`, and `POST /helm/chart/oci/install` for OCI charts.
  - Cluster targeting via the `cluster-id` header; cluster/workspace API key with editor rights.
- **Cross-reference** added in `deploying-applications/blueprints.mdx`.

## Verification
- Routes, request bodies, and header-based scoping verified against `mo-platform-api-service` (`helm/blueprints` and `helm/chart` controllers; scope resolved from `cluster-id`/`workspace-name`/`organization-id` headers; no `/v1` prefix).
- `mintlify broken-links` — clean (incl. the `#deploy-a-blueprint` anchor).
- `mintlify dev` — both pages render 200; new section and cross-reference render.

No `openapi.json` change (these endpoints are not maintained there, consistent with the existing API-page examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)